### PR TITLE
chore: update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         spec_file: "specs/${{ matrix.spec }}.spec"
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v4
       with:
         name: Binary RPM
         path: ${{ steps.rpm.outputs.rpm_dir_path }}


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

actions/upload-artifact is v1.0.0 which is ancient

## What is the new behavior?

- Updating to actions/upload-artifact@v4

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information


