### PR TITLE
ci: adding arch to artifact name for proper paralel builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
             version: "42"
             arch: amd64
     env:
-      IMAGEARTIFACT: builder-${{ matrix.baseimage }}-${{ matrix.version }}
+      IMAGEARTIFACT: builder-${{ matrix.baseimage }}-${{ matrix.version }}-${{ matrix.arch }}
       IMAGETAG: builder-${{ matrix.baseimage }}:${{ matrix.version }}
     runs-on: ubuntu-latest
     steps:
@@ -176,7 +176,7 @@ jobs:
 
       - id: artifact_name
         run: |
-          echo "name=$(echo ${IMAGETAG} | sed 's/:/-/')" >> $GITHUB_OUTPUT
+          echo "name=$(echo ${IMAGETAG} | sed 's/:/-/')-${{ matrix.arch }}" >> $GITHUB_OUTPUT
 
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -218,7 +218,7 @@ jobs:
             version: "9"
             arch: amd64
     env:
-      IMAGEARTIFACT: builder-${{ matrix.baseimage }}-${{ matrix.version }}
+      IMAGEARTIFACT: builder-${{ matrix.baseimage }}-${{ matrix.version }}-${{ matrix.arch }}
       IMAGETAG: builder-${{ matrix.baseimage }}:${{ matrix.version }}
       BASEIMAGE: ${{ matrix.baseimage }}:${{ matrix.version }}
     steps:


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently we don;t add arch to the name of the artifacts, which has issues with double artifact uploads

## What is the new behavior?

- We have added arch to the artifact name

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information


