### PR TITLE
ci: missing env key for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,7 @@ jobs:
         arch:
           - arm64
           - amd64
+    env:
       IMAGETAG: builder-${{ matrix.baseimage }}:${{ matrix.version }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Missing env key so release workflow does not work properly

## What is the new behavior?

- env key add
- release workflow should now work as expected
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information


