### PR TITLE
fix: ci broken unless running pr from repo itself

### DIFF
--- a/.github/workflows/ci-run-on-pr.yaml
+++ b/.github/workflows/ci-run-on-pr.yaml
@@ -220,6 +220,7 @@ jobs:
           DOCKER_BUILDKIT: 1
 
       - name: sign rpm's
+        if: ${{ env.GPG_KEY_B64 != '' }}
         run: |
           docker-compose up rpmsigner --exit-code-from rpmsigner
         env:
@@ -276,6 +277,7 @@ jobs:
           docker-compose up rpmdownloader --exit-code-from rpmdownloader
 
       - name: sign rpm's
+        if: ${{ env.GPG_KEY_B64 != '' }}
         run: |
           docker-compose up rpmsigner --exit-code-from rpmsigner
         env:


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When creating a PR from a branch outside of mannemsolutions/rpm-builder, ci does not work due to lack of GPG key

## What is the new behavior?

- if statement skips rpm step unless GPG secret is set

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information


