### PR TITLE
refactor: Chainsmith has moved home to the pgvillage umbrella and paths changed

### DIFF
--- a/config/github2spec.yaml
+++ b/config/github2spec.yaml
@@ -1,11 +1,11 @@
 template: /host/rpmbuilder/templates/spec.j2
 dest: /host/specs/
 repositories:
-  ChainSmithGo:
-    organization: dbyond-nl
+  chainsmith:
+    organization: pgvillage-tools
     asset_filter: 'chainsmith_{{ version }}_linux_{{ binary_arch }}.tar.gz$'
     files:
-      - src: 'chainsmith'
+      - src: '{{ repository }}'
         dest: '%{_bindir}/{{ repository }}'
         mode: '0755'
   pgtester:


### PR DESCRIPTION
The Github spec file was changed to reflect the new URL and path for chainsmith to the pgvillage-tools umbrella

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Files were pulled from dbyond-nl organisation with repo name ChainSmithGo
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: # (issue)

## What is the new behavior?
Files are pulled from pgvillage-tools with repo name chainsmith
<!-- Please describe the behavior or changes that are being added by this PR. -->


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

